### PR TITLE
ci: fix last error, improvements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,36 +4,39 @@ on:
   push:
     tags:
       - "v*" # Triggers when pushing tags like v1.0.0
-
   workflow_dispatch:
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:
+    name: Publish
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: "pnpm"
+          node-version: latest
+          cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build package
-        run: pnpm run build
+        run: pnpm build
 
       - name: Publish to npm
-        run: pnpm publish --access public
+        run: pnpm publish --provenance --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Fix your last run's error (`--no-git-checks` option)
- Handle concurrent CI runs (when it happens, cancels the previous run automatically)
- Remove a useless option on `pnpm` step (it's `null` by default, which is the same as `false`)
- Use the latest Node version to enjoy the latest features (it might be controversial, but I don't really see when it can be an issue)
- Add the `--provenance` flag to `publish` so your releases will be "verified" on npm (it's more and more recommended to do this nowadays, and it adds another layer of trust for users)
- Misc typo and naming stuff

I personally use this (almost) exact setup for my own repositories, and it works flawlessly.

If I can also give additional off-topic tips, I would remove the `package-lock.json` so it doesn't mess with `pnpm-lock.yaml` and it makes it clearer that this repo uses pnpm. I would also remove your `.prettierignore` file because I don't see why you wouldn't want to format your CSS file, it's the only "source" file of this repo :D (or at least use `src/*.css` in it so you don't have to change it if you ever rename it once again/add another one!)