### PR TITLE
feat(fix): fix local install, added canary workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,62 @@
+name: Publish canary to npm with pnpm
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  id-token: write
+
+jobs:
+  release:
+    name: Release Canary
+    runs-on: upnpmtu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Publish canary to npm
+        run: |
+          # --- Check if package exists in npm registry ---
+          package_name=$(pnpx json -f package.json -a name)
+          npm view "$package_name" 2>/dev/null || {
+            echo "$package_name does not exist in the npm registry. Skipping publish."
+            exit 0
+          }
+          # --- Determine and release the next canary version ---
+          current_latest=$(pnpx json -f package.json -a version)
+          IFS='.' read -r major minor patch <<<"$current_latest"
+          upcoming_minor="$major.$((minor + 1)).0"
+          current_canary=$(npm view "$package_name" dist-tags.canary 2>/dev/null)
+          if [ -z "$current_canary" ]; then
+            release_version="$upcoming_minor-canary.0"
+          else
+            IFS='.-' read -r canary_major canary_minor canary_patch canary_tag canary_version <<<"$current_canary"
+            release_version="$canary_major.$canary_minor.$canary_patch-canary.$((canary_version + 1))"
+          fi
+          pnpx json -I -f package.json -e "this.version=\"$release_version\""
+          pnpm publish --provenance --access public --no-git-checks --tag canary
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "pnpx @tailwindcss/cli -i ./src/tw-animate.css -o ./dist/tw-animate.css -m",
     "format": "prettier --write --ignore-unknown .",
-    "prepare": "if [ \"$NODE_ENV\" != \"production\" ]; then pnpx simple-git-hooks; fi"
+    "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpx lint-staged",


### PR DESCRIPTION
- fix: pnpx simple-git-hooks disables the ability on first clone and install (aka users can't run project locally using pnpm)
- feat: on deployment at main, release next minor version's canary

e.g. if current version is 1.2.4, via push on main ([demo ref](https://github.com/nrjdalal/the-typescript-starter)), releases
- 1.3.0-canary.0
and on subsequent pushes
- 1.3.0-canary.1 ...

---

also did set fetch depth to 0 for faster cloning purposes

<img width="786" alt="Screenshot 2025-03-21 at 6 47 50 PM" src="https://github.com/user-attachments/assets/67e70de2-dba2-4825-9278-5bf6c6b9e6f5" />
