### PR TITLE
fix: accordion and collapisble should be seperated

### DIFF
--- a/docs/animations/accordion.md
+++ b/docs/animations/accordion.md
@@ -24,20 +24,14 @@ Animation for opening an accordion. This animation slides the accordion content 
 <td>
 
 ```css
-animation: content-down var(--tw-duration, 200ms) ease-out;
+animation: accordion-down var(--tw-duration, 200ms) ease-out;
 
-@keyframes content-down {
+@keyframes accordion-down {
   from {
     height: 0;
   }
   to {
-    height: var(
-      --radix-accordion-content-height,
-      var(
-        --bits-accordion-content-height,
-        var(--radix-collapsible-content-height, var(--bits-collapsible-content-height, auto))
-      )
-    );
+    height: var(--radix-accordion-content-height, var(--bits-accordion-content-height, auto));
   }
 }
 ```
@@ -71,17 +65,11 @@ Animation for closing an accordion. This animation slides the accordion content 
 <td>
 
 ```css
-animation: content-up var(--tw-duration, 200ms) ease-out;
+animation: accordion-up var(--tw-duration, 200ms) ease-out;
 
-@keyframes content-up {
+@keyframes accordion-up {
   from {
-    height: var(
-      --radix-accordion-content-height,
-      var(
-        --bits-accordion-content-height,
-        var(--radix-collapsible-content-height, var(--bits-collapsible-content-height, auto))
-      )
-    );
+    height: var(--radix-accordion-content-height, var(--bits-accordion-content-height, auto));
   }
   to {
     height: 0;

--- a/docs/animations/collapsible.md
+++ b/docs/animations/collapsible.md
@@ -24,20 +24,14 @@ Animation for opening a collapsible. This animation slides the collapsible conte
 <td>
 
 ```css
-animation: content-down var(--tw-duration, 200ms) ease-out;
+animation: collapsible-down var(--tw-duration, 200ms) ease-out;
 
-@keyframes content-down {
+@keyframes collapsible-down {
   from {
     height: 0;
   }
   to {
-    height: var(
-      --radix-accordion-content-height,
-      var(
-        --bits-accordion-content-height,
-        var(--radix-collapsible-content-height, var(--bits-collapsible-content-height, auto))
-      )
-    );
+    height: var(--radix-collapsible-content-height, var(--bits-collapsible-content-height, auto));
   }
 }
 ```
@@ -71,17 +65,11 @@ Animation for closing a collapsible. This animation slides the collapsible conte
 <td>
 
 ```css
-animation: content-up var(--tw-duration, 200ms) ease-out;
+animation: collapsible-up var(--tw-duration, 200ms) ease-out;
 
-@keyframes content-up {
+@keyframes collapsible-up {
   from {
-    height: var(
-      --radix-accordion-content-height,
-      var(
-        --bits-accordion-content-height,
-        var(--radix-collapsible-content-height, var(--bits-collapsible-content-height, auto))
-      )
-    );
+    height: var(--radix-collapsible-content-height, var(--bits-collapsible-content-height, auto));
   }
   to {
     height: 0;

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -60,12 +60,6 @@
   --animate-in: enter var(--tw-duration, 150ms) var(--tw-ease, ease);
   --animate-out: exit var(--tw-duration, 150ms) var(--tw-ease, ease);
 
-  --animate-accordion-down: accordion-down var(--tw-duration, 200ms) ease-out;
-  --animate-accordion-up: accordion-up var(--tw-duration, 200ms) ease-out;
-  --animate-collapsible-down: collapsible-down var(--tw-duration, 200ms) ease-out;
-  --animate-collapsible-up: collapsible-up var(--tw-duration, 200ms) ease-out;
-  --animate-caret-blink: caret-blink 1.25s ease-out infinite;
-
   @keyframes enter {
     from {
       opacity: var(--tw-enter-opacity, 1);
@@ -97,6 +91,11 @@
    * `interpolate-size: allow-keywords` to be set and is currently not widely
    * supported. See <https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size>
    */
+
+  --animate-accordion-down: accordion-down var(--tw-duration, 200ms) ease-out;
+  --animate-accordion-up: accordion-up var(--tw-duration, 200ms) ease-out;
+  --animate-collapsible-down: collapsible-down var(--tw-duration, 200ms) ease-out;
+  --animate-collapsible-up: collapsible-up var(--tw-duration, 200ms) ease-out;
 
   @keyframes accordion-down {
     from {
@@ -133,6 +132,8 @@
       height: 0;
     }
   }
+
+  --animate-caret-blink: caret-blink 1.25s ease-out infinite;
 
   @keyframes caret-blink {
     0%,

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -78,20 +78,6 @@
     }
   }
 
-  /*
-   * The `--radix-accordion-content-height` variable is set by Radix UI's
-   * Accordion component. The `--bits-accordion-content-height` variable is set
-   * by Bits' Accordion component. The `--radix-collapsible-content-height`
-   * variable is set by Radix UI's Collapsible component. The
-   * `--bits-collapsible-content-height` variable is set by Bits' Collapsible
-   * component.
-   *
-   * These variables are used to animate the height of the content when it is
-   * expanded or collapsed. `auto` is used as a fallback value but it requires
-   * `interpolate-size: allow-keywords` to be set and is currently not widely
-   * supported. See <https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size>
-   */
-
   --animate-accordion-down: accordion-down var(--tw-duration, 200ms) ease-out;
   --animate-accordion-up: accordion-up var(--tw-duration, 200ms) ease-out;
 
@@ -112,6 +98,20 @@
       height: 0;
     }
   }
+
+  /*
+  * The `--radix-accordion-content-height` variable is set by Radix UI's
+  * Accordion component. The `--bits-accordion-content-height` variable is set
+  * by Bits' Accordion component. The `--radix-collapsible-content-height`
+  * variable is set by Radix UI's Collapsible component. The
+  * `--bits-collapsible-content-height` variable is set by Bits' Collapsible
+  * component.
+  *
+  * These variables are used to animate the height of the content when it is
+  * expanded or collapsed. `auto` is used as a fallback value but it requires
+  * `interpolate-size: allow-keywords` to be set and is currently not widely
+  * supported. See <https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size>
+  */
 
   --animate-collapsible-down: collapsible-down var(--tw-duration, 200ms) ease-out;
   --animate-collapsible-up: collapsible-up var(--tw-duration, 200ms) ease-out;

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -79,16 +79,13 @@
   }
 
   /*
-  * Radix UI and Bits UI utilize CSS variables to define the height of Accordion 
-  * and Collapsible content during open/close animations. 
+  * Radix and Bits UI utilize CSS variables to define the height of Accordion and Collapsible
+  * content during open/close animations. The `--radix/bits-accordion-content-height` variables
+  * control the height of Accordion content, while collapsible variables are used for Collapsibles.
   *
-  * The `--radix-accordion-content-height` and `--bits-accordion-content-height` 
-  * variables control the height of Accordion content, while collapsible variables
-  * manages the height of Collapsible content.
-  *
-  * While `auto` serves as a fallback value, it requires the `interpolate-size:
-  * allow-keywords` property, which currently lacks broad browser support.
-  * Ref: <https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size>
+  * The fallback value `auto` is used here, but it depends on the `interpolate-size: allow-keywords`
+  * property, which currently has limited browser support. For more details, see: 
+  * <https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size>
   */
 
   --animate-accordion-down: accordion-down var(--tw-duration, 200ms) ease-out;

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -60,10 +60,10 @@
   --animate-in: enter var(--tw-duration, 150ms) var(--tw-ease, ease);
   --animate-out: exit var(--tw-duration, 150ms) var(--tw-ease, ease);
 
-  --animate-accordion-down: content-down var(--tw-duration, 200ms) ease-out;
-  --animate-accordion-up: content-up var(--tw-duration, 200ms) ease-out;
-  --animate-collapsible-down: content-down var(--tw-duration, 200ms) ease-out;
-  --animate-collapsible-up: content-up var(--tw-duration, 200ms) ease-out;
+  --animate-accordion-down: accordion-down var(--tw-duration, 200ms) ease-out;
+  --animate-accordion-up: accordion-up var(--tw-duration, 200ms) ease-out;
+  --animate-collapsible-down: collapsible-down var(--tw-duration, 200ms) ease-out;
+  --animate-collapsible-up: collapsible-up var(--tw-duration, 200ms) ease-out;
   --animate-caret-blink: caret-blink 1.25s ease-out infinite;
 
   @keyframes enter {

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -129,8 +129,6 @@
     }
   }
 
-  /* Caret animations */
-
   --animate-caret-blink: caret-blink 1.25s ease-out infinite;
 
   @keyframes caret-blink {

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -98,30 +98,36 @@
    * supported. See <https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size>
    */
 
-  @keyframes content-down {
+  @keyframes accordion-down {
     from {
       height: 0;
     }
     to {
-      height: var(
-        --radix-accordion-content-height,
-        var(
-          --bits-accordion-content-height,
-          var(--radix-collapsible-content-height, var(--bits-collapsible-content-height, auto))
-        )
-      );
+      height: var(--radix-accordion-content-height, var(--bits-accordion-content-height));
     }
   }
 
-  @keyframes content-up {
+  @keyframes accordion-up {
     from {
-      height: var(
-        --radix-accordion-content-height,
-        var(
-          --bits-accordion-content-height,
-          var(--radix-collapsible-content-height, var(--bits-collapsible-content-height, auto))
-        )
-      );
+      height: var(--radix-accordion-content-height, var(--bits-accordion-content-height));
+    }
+    to {
+      height: 0;
+    }
+  }
+
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(--radix-collapsible-content-height, var(--bits-collapsible-content-height));
+    }
+  }
+
+  @keyframes collapsible-up {
+    from {
+      height: var(--radix-collapsible-content-height, var(--bits-collapsible-content-height));
     }
     to {
       height: 0;

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -78,8 +78,24 @@
     }
   }
 
+  /*
+  * The `--radix-accordion-content-height` variable is set by Radix UI's
+  * Accordion component. The `--bits-accordion-content-height` variable is set
+  * by Bits' Accordion component. The `--radix-collapsible-content-height`
+  * variable is set by Radix UI's Collapsible component. The
+  * `--bits-collapsible-content-height` variable is set by Bits' Collapsible
+  * component.
+  *
+  * These variables are used to animate the height of the content when it is
+  * expanded or collapsed. `auto` is used as a fallback value but it requires
+  * `interpolate-size: allow-keywords` to be set and is currently not widely
+  * supported. See <https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size>
+  */
+
   --animate-accordion-down: accordion-down var(--tw-duration, 200ms) ease-out;
   --animate-accordion-up: accordion-up var(--tw-duration, 200ms) ease-out;
+  --animate-collapsible-down: collapsible-down var(--tw-duration, 200ms) ease-out;
+  --animate-collapsible-up: collapsible-up var(--tw-duration, 200ms) ease-out;
 
   @keyframes accordion-down {
     from {
@@ -98,23 +114,6 @@
       height: 0;
     }
   }
-
-  /*
-  * The `--radix-accordion-content-height` variable is set by Radix UI's
-  * Accordion component. The `--bits-accordion-content-height` variable is set
-  * by Bits' Accordion component. The `--radix-collapsible-content-height`
-  * variable is set by Radix UI's Collapsible component. The
-  * `--bits-collapsible-content-height` variable is set by Bits' Collapsible
-  * component.
-  *
-  * These variables are used to animate the height of the content when it is
-  * expanded or collapsed. `auto` is used as a fallback value but it requires
-  * `interpolate-size: allow-keywords` to be set and is currently not widely
-  * supported. See <https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size>
-  */
-
-  --animate-collapsible-down: collapsible-down var(--tw-duration, 200ms) ease-out;
-  --animate-collapsible-up: collapsible-up var(--tw-duration, 200ms) ease-out;
 
   @keyframes collapsible-down {
     from {

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -133,6 +133,8 @@
     }
   }
 
+  /* Caret animations */
+
   --animate-caret-blink: caret-blink 1.25s ease-out infinite;
 
   @keyframes caret-blink {

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -79,17 +79,16 @@
   }
 
   /*
-  * The `--radix-accordion-content-height` variable is set by Radix UI's
-  * Accordion component. The `--bits-accordion-content-height` variable is set
-  * by Bits' Accordion component. The `--radix-collapsible-content-height`
-  * variable is set by Radix UI's Collapsible component. The
-  * `--bits-collapsible-content-height` variable is set by Bits' Collapsible
-  * component.
+  * Radix UI and Bits UI utilize CSS variables to define the height of Accordion 
+  * and Collapsible content during open/close animations. 
   *
-  * These variables are used to animate the height of the content when it is
-  * expanded or collapsed. `auto` is used as a fallback value but it requires
-  * `interpolate-size: allow-keywords` to be set and is currently not widely
-  * supported. See <https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size>
+  * The `--radix-accordion-content-height` and `--bits-accordion-content-height` 
+  * variables control the height of Accordion content, while collapsible variables
+  * manages the height of Collapsible content.
+  *
+  * While `auto` serves as a fallback value, it requires the `interpolate-size:
+  * allow-keywords` property, which currently lacks broad browser support.
+  * Ref: <https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size>
   */
 
   --animate-accordion-down: accordion-down var(--tw-duration, 200ms) ease-out;

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -94,8 +94,6 @@
 
   --animate-accordion-down: accordion-down var(--tw-duration, 200ms) ease-out;
   --animate-accordion-up: accordion-up var(--tw-duration, 200ms) ease-out;
-  --animate-collapsible-down: collapsible-down var(--tw-duration, 200ms) ease-out;
-  --animate-collapsible-up: collapsible-up var(--tw-duration, 200ms) ease-out;
 
   @keyframes accordion-down {
     from {
@@ -114,6 +112,9 @@
       height: 0;
     }
   }
+
+  --animate-collapsible-down: collapsible-down var(--tw-duration, 200ms) ease-out;
+  --animate-collapsible-up: collapsible-up var(--tw-duration, 200ms) ease-out;
 
   @keyframes collapsible-down {
     from {

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -102,13 +102,13 @@
       height: 0;
     }
     to {
-      height: var(--radix-accordion-content-height, var(--bits-accordion-content-height));
+      height: var(--radix-accordion-content-height, var(--bits-accordion-content-height, auto));
     }
   }
 
   @keyframes accordion-up {
     from {
-      height: var(--radix-accordion-content-height, var(--bits-accordion-content-height));
+      height: var(--radix-accordion-content-height, var(--bits-accordion-content-height, auto));
     }
     to {
       height: 0;
@@ -120,13 +120,13 @@
       height: 0;
     }
     to {
-      height: var(--radix-collapsible-content-height, var(--bits-collapsible-content-height));
+      height: var(--radix-collapsible-content-height, var(--bits-collapsible-content-height, auto));
     }
   }
 
   @keyframes collapsible-up {
     from {
-      height: var(--radix-collapsible-content-height, var(--bits-collapsible-content-height));
+      height: var(--radix-collapsible-content-height, var(--bits-collapsible-content-height, auto));
     }
     to {
       height: 0;


### PR DESCRIPTION
should be seperated as sometime accordion and collapisble contains each other, and wrong var refs are passed

@Wombosvideo this need to be fixed asap as the behaviour breaks with current multi ref, I guess
