### PR TITLE
feat: add support for Kobalte UI variables to accordion and collapsible animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ To customize the animation parameters, use the following classes:
 
 ### Ready-to-Use Animations
 
-| Class                                  | Description                                                                                                                                                                              |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`accordion-down`][Docs_Accordion]     | Accordion down animation. Requires one of `--radix-accordion-content-height`, `--bits-accordion-content-height` or `--reka-accordion-content-height` to be set to the content's height.  |
-| [`accordion-up`][Docs_Accordion]       | Accordion up animation. Requires one of `--radix-accordion-content-height`, `--bits-accordion-content-height` or `--reka-accordion-content-height` to be set to the content's height.    |
-| [`collapsible-down`][Docs_Collapsible] | Collapsible down animation. Requires `--radix-collapsible-content-height`, `--bits-collapsible-content-height` or `--reka-collapsible-content-height` to be set to the content's height. |
-| [`collapsible-up`][Docs_Collapsible]   | Collapsible up animation. Requires `--radix-collapsible-content-height`, `--bits-collapsible-content-height` or `--reka-collapsible-content-height` to be set to the content's height.   |
-| [`caret-blink`][Docs_Caret]            | Blinking animation for caret/cursor.                                                                                                                                                     |
+| Class                                  | Description                                                                                                                                                                                                                 |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`accordion-down`][Docs_Accordion]     | Accordion down animation. Requires one of `--radix-accordion-content-height`, `--bits-accordion-content-height`, `--reka-accordion-content-height` or `--kb-accordion-content-height` to be set to the content's height.    |
+| [`accordion-up`][Docs_Accordion]       | Accordion up animation. Requires one of `--radix-accordion-content-height`, `--bits-accordion-content-height`, `--reka-accordion-content-height` or `--kb-accordion-content-height` to be set to the content's height.      |
+| [`collapsible-down`][Docs_Collapsible] | Collapsible down animation. Requires `--radix-collapsible-content-height`, `--bits-collapsible-content-height`, `--reka-collapsible-content-height` or `--kb-collapsible-content-height` to be set to the content's height. |
+| [`collapsible-up`][Docs_Collapsible]   | Collapsible up animation. Requires `--radix-collapsible-content-height`, `--bits-collapsible-content-height`, `--reka-collapsible-content-height` or `--kb-collapsible-content-height` to be set to the content's height.   |
+| [`caret-blink`][Docs_Caret]            | Blinking animation for caret/cursor.                                                                                                                                                                                        |
 
 By the way, if you don't use some of the above animations, they will not be included in the final CSS file. This is because Tailwind CSS kind of does tree-shaking for you. So, if you don't use `accordion-down`, it won't be included in the final CSS file.
 

--- a/docs/animations/accordion.md
+++ b/docs/animations/accordion.md
@@ -183,9 +183,31 @@ import {
 
 Learn more about Reka's accordion primitive in the [Reka documentation][Reka_Docs].
 
+### Using Kobalte
+
+Kobalte automatically sets the `--kb-accordion-content-height` variable. Just use the headless accordion component primitive!
+
+```jsx
+import { Accordion } from "@kobalte/core/accordion";
+
+export default () => (
+  <Accordion.Root>
+    <Accordion.Item>
+      <Accordion.Header>
+        <Accordion.Trigger>...</Accordion.Trigger>
+      </Accordion.Header>
+      <Accordion.Content>...</Accordion.Content>
+    </Accordion.Item>
+  </Accordion.Root>
+);
+```
+
+Learn more about Kobalte's accordion primitive in the [Kobalte documentation][Kobalte_Docs].
+
 <!-- Links -->
 
 [MDN_Interpolate_Size]: https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size
 [Radix_Docs]: https://radix-ui.com/docs/primitives/components/accordion#content
 [Bits_Docs]: https://bits-ui.com/docs/components/accordion#content
 [Reka_Docs]: https://reka-ui.com/docs/components/accordion#content
+[Kobalte_Docs]: https://kobalte.dev/docs/core/components/accordion#animating-content-size

--- a/docs/animations/collapsible.md
+++ b/docs/animations/collapsible.md
@@ -165,9 +165,27 @@ import { CollapsibleContent, CollapsibleRoot, CollapsibleTrigger } from "reka-ui
 
 Learn more about Reka's collapsible primitive in the [Reka documentation][Reka_Docs].
 
+### Using Kobalte
+
+Kobalte automatically sets the `--kb-collapsible-content-height` variable. Just use the headless collapsible component primitive!
+
+```jsx
+import { Collapsible } from "@kobalte/core/collapsible";
+
+export default () => (
+  <Collapsible.Root>
+    <Collapsible.Trigger />
+    <Collapsible.Content />
+  </Collapsible.Root>
+);
+```
+
+Learn more about Kobalte's collapsible primitive in the [Kobalte documentation][Kobalte_Docs].
+
 <!-- Links -->
 
 [MDN_Interpolate_Size]: https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size
 [Radix_Docs]: https://www.radix-ui.com/primitives/docs/components/collapsible#content
 [Bits_Docs]: https://bits-ui.com/docs/components/collapsible#content
 [Reka_Docs]: https://reka-ui.com/docs/components/collapsible#content
+[Kobalte_Docs]: https://kobalte.dev/docs/core/components/collapsible#animating-content-size

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -172,7 +172,10 @@
     to {
       height: var(
         --radix-accordion-content-height,
-        var(--bits-accordion-content-height, var(--reka-accordion-content-height, auto))
+        var(
+          --bits-accordion-content-height,
+          var(--reka-accordion-content-height, var(--kb-accordion-content-height, auto))
+        )
       );
     }
   }
@@ -181,7 +184,10 @@
     from {
       height: var(
         --radix-accordion-content-height,
-        var(--bits-accordion-content-height, var(--reka-accordion-content-height, auto))
+        var(
+          --bits-accordion-content-height,
+          var(--reka-accordion-content-height, var(--kb-accordion-content-height, auto))
+        )
       );
     }
     to {
@@ -196,7 +202,10 @@
     to {
       height: var(
         --radix-collapsible-content-height,
-        var(--bits-collapsible-content-height, var(--reka-collapsible-content-height, auto))
+        var(
+          --bits-collapsible-content-height,
+          var(--reka-collapsible-content-height, var(--kb-collapsible-content-height, auto))
+        )
       );
     }
   }
@@ -205,7 +214,10 @@
     from {
       height: var(
         --radix-collapsible-content-height,
-        var(--bits-collapsible-content-height, var(--reka-collapsible-content-height, auto))
+        var(
+          --bits-collapsible-content-height,
+          var(--reka-collapsible-content-height, var(--kb-collapsible-content-height, auto))
+        )
       );
     }
     to {


### PR DESCRIPTION
Adds `--kb-accordion-content-height` and `--kb-collapsible-content-height` to the `accordion-` and `collapsible-` utilities  and updates the documentation accordingly.

Fixes #36.