### PR TITLE
feat: easily allow setting accordion and collapsible heights to arbitrary values

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,15 +137,25 @@ To customize the animation parameters, use the following classes:
 
 ### Ready-to-Use Animations
 
-| Class                                  | Description                                                                                                                                                                              |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`accordion-down`][Docs_Accordion]     | Accordion down animation. Requires one of `--radix-accordion-content-height`, `--bits-accordion-content-height` or `--reka-accordion-content-height` to be set to the content's height.  |
-| [`accordion-up`][Docs_Accordion]       | Accordion up animation. Requires one of `--radix-accordion-content-height`, `--bits-accordion-content-height` or `--reka-accordion-content-height` to be set to the content's height.    |
-| [`collapsible-down`][Docs_Collapsible] | Collapsible down animation. Requires `--radix-collapsible-content-height`, `--bits-collapsible-content-height` or `--reka-collapsible-content-height` to be set to the content's height. |
-| [`collapsible-up`][Docs_Collapsible]   | Collapsible up animation. Requires `--radix-collapsible-content-height`, `--bits-collapsible-content-height` or `--reka-collapsible-content-height` to be set to the content's height.   |
-| [`caret-blink`][Docs_Caret]            | Blinking animation for caret/cursor.                                                                                                                                                     |
+| Class                                  | Description                                                                                                      |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [`accordion-down`][Docs_Accordion]     | Accordion down animation. Requires [`accordion-h-*`][Docs_AccordionHeight] to set to the content's height.       |
+| [`accordion-up`][Docs_Accordion]       | Accordion up animation. Requires [`accordion-h-*`][Docs_AccordionHeight] to set to the content's height.         |
+| [`collapsible-down`][Docs_Collapsible] | Collapsible down animation. Requires [`collapsible-h-*`][Docs_CollapsibleHeight] to set to the content's height. |
+| [`collapsible-up`][Docs_Collapsible]   | Collapsible up animation. Requires [`collapsible-h-*`][Docs_CollapsibleHeight] to set to the content's height.   |
+| [`caret-blink`][Docs_Caret]            | Blinking animation for caret/cursor.                                                                             |
 
-By the way, if you don't use some of the above animations, they will not be included in the final CSS file. This is because Tailwind CSS kind of does tree-shaking for you. So, if you don't use `accordion-down`, it won't be included in the final CSS file.
+#### Accordion and Collapsible Utilities
+
+For the accordion and collapsible animations to work correctly, you need to set the height of the content using the `accordion-h-*` or `collapsible-h-*` utilities. These utilities define the height of the content that will be animated.
+
+| Class             | Description                                                                                                                                                                                                 |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accordion-h-*`   | Sets the height of the accordion content to the given value. Possible values: Any `<number>` (spacing units) or any other `[<value>]`. This is required for the accordion animations to work correctly.     |
+| `collapsible-h-*` | Sets the height of the collapsible content to the given value. Possible values: Any `<number>` (spacing units) or any other `[<value>]`. This is required for the collapsible animations to work correctly. |
+
+> [!TIP]
+> If you don't use any of the above animations, they will not be included in the final CSS file. This is because Tailwind CSS kind of does tree-shaking for you. So, if you don't use `accordion-down`, it won't be included in the final CSS file.
 
 ## Examples
 
@@ -209,7 +219,9 @@ By the way, if you don't use some of the above animations, they will not be incl
 [Docs_Spin]: ./docs/transforms/rotate.md
 [Docs_Slide]: ./docs/transforms/translate.md
 [Docs_Accordion]: ./docs/animations/accordion.md
+[Docs_AccordionHeight]: ./docs/animations/accordion.md#accordion-h-
 [Docs_Collapsible]: ./docs/animations/collapsible.md
+[Docs_CollapsibleHeight]: ./docs/animations/collapsible.md#collapsible-h-
 [Docs_Caret]: ./docs/animations/caret-blink.md
 [MDN_Duration]: https://developer.mozilla.org/en-US/docs/Web/CSS/animation-duration
 [MDN_Ease]: https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timing-function

--- a/docs/animations/accordion.md
+++ b/docs/animations/accordion.md
@@ -88,23 +88,83 @@ animation: accordion-up var(--tw-duration, 200ms) ease-out;
 </tbody>
 </table>
 
+## `accordion-h-*`
+
+This utility sets the height of the accordion content. It is used to ensure that the accordion content has a defined height for the animations to work correctly.
+
+<table>
+<thead>
+<tr>
+<th>Class</th>
+<th>Styles</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+`accordion-h-<number>`
+
+</td>
+<td>
+
+```css
+--radix-accordion-content-height: calc(<number> * var(--spacing));
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`accordion-h-(<custom-property>)`
+
+</td>
+<td>
+
+```css
+--radix-accordion-content-height: var(<custom-property>);
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`accordion-h-[<value>]`
+
+</td>
+<td>
+
+```css
+--radix-accordion-content-height: <value>;
+```
+
+</td>
+</tr>
+</tbody>
+</table>
+
 ## Setting content height
 
-Until browser support for [`interpolate-size: allow-keywords`][MDN_Interpolate_Size] is more widespread, a CSS variable is used to define the full height of the accordion content. You can set one of the following variables to the accordion content to set the height:
+Until browser support for [`interpolate-size: allow-keywords`][MDN_Interpolate_Size] is more widespread, a CSS variable is used to define the full height of the accordion content.
+The following sections explain how to set the height of the accordion content using different methods.
 
-- `--radix-accordion-content-height` as in the [Radix documentation][Radix_Docs]
-- `--bits-accordion-content-height` as in the [BitsUI documentation][Bits_Docs]
-- `--reka-accordion-content-height` as in the [Reka documentation][Reka_Docs]
+### Using the `accordion-h-*` utility
 
-Check out the [setting content height](#setting-content-height) section for more information.
+You can use the `accordion-h-*` utility to set the height of the accordion content. This utility sets the `--radix-accordion-content-height` CSS variable, which is used by the animations.
 
-### HTML
+```html
+<div class="accordion-h-(--abc-accordion-content-height)">...</div>
+```
+
+### Using inline styles
 
 ```html
 <div style="--radix-accordion-content-height: 1.75em">...</div>
 ```
 
-### JavaScript
+### Using JavaScript
 
 ```js
 document

--- a/docs/animations/collapsible.md
+++ b/docs/animations/collapsible.md
@@ -88,27 +88,87 @@ animation: collapsible-up var(--tw-duration, 200ms) ease-out;
 </tbody>
 </table>
 
+## `collapsible-h-*`
+
+This utility sets the height of the collapsible content. It is used to ensure that the collapsible content has a defined height for the animations to work correctly.
+
+<table>
+<thead>
+<tr>
+<th>Class</th>
+<th>Styles</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+`collapsible-h-<number>`
+
+</td>
+<td>
+
+```css
+--radix-collapsible-content-height: calc(<number> * var(--spacing));
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`collapsible-h-(<custom-property>)`
+
+</td>
+<td>
+
+```css
+--radix-collapsible-content-height: var(<custom-property>);
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`collapsible-h-[<value>]`
+
+</td>
+<td>
+
+```css
+--radix-collapsible-content-height: <value>;
+```
+
+</td>
+</tr>
+</tbody>
+</table>
+
 ## Setting content height
 
-Until browser support for [`interpolate-size: allow-keywords`][MDN_Interpolate_Size] is more widespread, a CSS variable is used to define the full height of the collapsible content. You can set one of the following variables to the collapsible content to set the height:
+Until browser support for [`interpolate-size: allow-keywords`][MDN_Interpolate_Size] is more widespread, a CSS variable is used to define the full height of the collapsible content.
+The following sections explain how to set the height of the collapsible content using different methods.
 
-- `--radix-collapsible-content-height` as in the [Radix documentation][Radix_Docs]
-- `--bits-collapsible-content-height` as in the [BitsUI documentation][Bits_Docs]
-- `--reka-collapsible-content-height` as in the [Reka documentation][Reka_Docs]
+### Using the `collapsible-h-*` utility
 
-Check out the [setting content height](#setting-content-height) section for more information.
+You can use the `collapsible-h-*` utility to set the height of the collapsible content. This utility sets the `--radix-collapsible-content-height` CSS variable, which is used by the animations.
 
-### HTML
+```html
+<div class="collapsible-h-(--abc-collapsible-content-height)">...</div>
+```
+
+### Using inline styles
 
 ```html
 <div style="--radix-collapsible-content-height: 1.75em">...</div>
 ```
 
-### JavaScript
+### Using JavaScript
 
 ```js
 document
-  .getElementById("faq-accordion-1")
+  .getElementById("faq-collapsible-1")
   .style.setProperty("--radix-collapsible-content-height", "1.75em");
 ```
 

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -231,12 +231,12 @@
 /* Utility classes */
 
 @utility accordion-h-* {
-  --radix-accordion-content-height: calc(--value(integer) * var(--spacing));
+  --radix-accordion-content-height: calc(--value(number) * var(--spacing));
   --radix-accordion-content-height: --value([ *]);
 }
 
 @utility collapsible-h-* {
-  --radix-collapsible-content-height: calc(--value(integer) * var(--spacing));
+  --radix-collapsible-content-height: calc(--value(number) * var(--spacing));
   --radix-collapsible-content-height: --value([ *]);
 }
 

--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -230,6 +230,16 @@
 
 /* Utility classes */
 
+@utility accordion-h-* {
+  --radix-accordion-content-height: calc(--value(integer) * var(--spacing));
+  --radix-accordion-content-height: --value([ *]);
+}
+
+@utility collapsible-h-* {
+  --radix-collapsible-content-height: calc(--value(integer) * var(--spacing));
+  --radix-collapsible-content-height: --value([ *]);
+}
+
 @utility animation-duration-* {
   --tw-animation-duration: calc(--value(number) * 1ms);
   --tw-animation-duration: --value(--animation-duration- *, [duration], "initial", [ *]);


### PR DESCRIPTION
## Description

Adds `accordion-h-*` and `collapsible-h-*` utilities to apply the content height CSS variable.

Allows either `number` values (in spacing units) or `[*]` any other value. This makes it possible to set the accordion height using 

```
accordion-h-(--abc-accordion-content-height)
```

Fixes #36.