### PR TITLE
feat(ng-primitives): Add ng-primitives support

### DIFF
--- a/src/tw-animate.css
+++ b/src/tw-animate.css
@@ -212,7 +212,8 @@
         --radix-accordion-content-height,
         var(
           --bits-accordion-content-height,
-          var(--reka-accordion-content-height, var(--kb-accordion-content-height, auto))
+          var(--reka-accordion-content-height, 
+          var(--kb-accordion-content-height, var(--ngp-accordion-content-height, auto)))
         )
       );
     }
@@ -224,7 +225,8 @@
         --radix-accordion-content-height,
         var(
           --bits-accordion-content-height,
-          var(--reka-accordion-content-height, var(--kb-accordion-content-height, auto))
+          var(--reka-accordion-content-height, 
+          var(--kb-accordion-content-height, var(--ngp-accordion-content-height, auto)))
         )
       );
     }


### PR DESCRIPTION
Adds --ngp-accordion-content-height variable to enable smooth height animations for ng-primitives accordion content.